### PR TITLE
corrected conda environment name  typo in 05_starting_with_data.md

### DIFF
--- a/doc/05_starting_with_data.md
+++ b/doc/05_starting_with_data.md
@@ -163,7 +163,7 @@ cd ~/2020_rotation_project/raw_data
 Then, use conda to install fastqc. Make sure you activate your rotation environment.
 
 ```
-conda activate 2020_rotation
+conda activate dib_rotation
 conda install fastqc
 ```
 


### PR DESCRIPTION
Corrected conda environment name from "2020_rotation" to"dib_rotation" for consistency with other modules.