### PR TITLE
[MRG] Include unix tutorial doc in background reading

### DIFF
--- a/doc/00a_unix.md
+++ b/doc/00a_unix.md
@@ -4,5 +4,6 @@ You will need to download the data for this lesson [here](https://figshare.com/a
 + [An Introduction to Shell](https://angus.readthedocs.io/en/2019/shell_intro/index.html).
 + [The Unix Shell](https://swcarpentry.github.io/shell-novice/)
 + [Introduction to using the shell in a High-Performance Computing context](https://hpc-carpentry.github.io/hpc-shell/)
++ [Unix Introduction for GGG courses at UC Davis](https://hackmd.io/5EfBWjCmTbWLgdC4rg8GZw#)
     - [Happy Belly Bioinformatics: Unix Crash Course](https://astrobiomike.github.io/unix/unix-intro)
     - [Hannah's Unix Cafe](https://github.com/ctb/hannahs-unix-cafe)

--- a/doc/00a_unix.md
+++ b/doc/00a_unix.md
@@ -4,3 +4,5 @@ You will need to download the data for this lesson [here](https://figshare.com/a
 + [An Introduction to Shell](https://angus.readthedocs.io/en/2019/shell_intro/index.html).
 + [The Unix Shell](https://swcarpentry.github.io/shell-novice/)
 + [Introduction to using the shell in a High-Performance Computing context](https://hpc-carpentry.github.io/hpc-shell/)
+    - [Happy Belly Bioinformatics: Unix Crash Course](https://astrobiomike.github.io/unix/unix-intro)
+    - [Hannah's Unix Cafe](https://github.com/ctb/hannahs-unix-cafe)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ theme:
   palette:
     primary: 'deep orange'
     accent: 'black'
-  
+
   # fun logos! see https://material.io/icons/
   icon:
     logo: material/school
@@ -25,14 +25,16 @@ theme:
   font:
     text: 'Roboto'
     code: 'Roboto Mono'
-  
+
 # optionally give a title for each page or section
 nav:
   - 'Home': 'index.md'
   - "Setup":
     - "Setting up Farm": "01_farm_account.md"
     - "Install Conda": "02_conda.md"
-  - "Background Reading": "03_background_reading.md"
+  - "Background Reading":
+    - "Scientific Literature": "03_background_reading.md"
+    - "Unix Tutorials": "00a_unix.md"
   - "Keeping a Lab Notebook": "04_documentation.md"
   - "Starting a Work Session": "04b_starting_a_work_session.md"
   - "Metagenomics Project":
@@ -46,3 +48,4 @@ nav:
     - "Automation, Workflows, and Repeatability": "11_workflows_and_repeatability.md"
     - "Version Control with Git and GitHub":  "12_angus_github.md"
     - "Contribute on GitHub": "13_contribute_on_github.md"
+


### PR DESCRIPTION
Fixes #64 

I added the unix tutorial doc to the mkdocs yaml file in under the background reading section.